### PR TITLE
fix: eslint is disabled

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,14 +1,6 @@
 {
   "dependencies": [
     {
-      "name": "@smithy/config-resolver",
-      "type": "build"
-    },
-    {
-      "name": "@smithy/node-config-provider",
-      "type": "build"
-    },
-    {
       "name": "@smithy/types",
       "type": "build"
     },
@@ -157,6 +149,14 @@
     },
     {
       "name": "@aws-sdk/lib-storage",
+      "type": "runtime"
+    },
+    {
+      "name": "@smithy/config-resolver",
+      "type": "runtime"
+    },
+    {
+      "name": "@smithy/node-config-provider",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -109,7 +109,7 @@
       "description": "Runs eslint against the codebase",
       "steps": [
         {
-          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern $@ src test bin build-tools projenrc .projenrc.ts",
+          "exec": "eslint --ext .ts,.tsx --fix --no-error-on-unmatched-pattern $@ lib test bin build-tools projenrc .projenrc.ts",
           "receiveArgs": true
         }
       ]
@@ -271,13 +271,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@smithy/config-resolver,@smithy/node-config-provider,@smithy/types,@types/archiver,@types/glob,@types/jest,@types/mime,@types/yargs,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,fs-extra,graceful-fs,jest,jszip,prettier,projen,ts-jest,ts-node,typescript,@aws-cdk/cloud-assembly-schema,@aws-cdk/cx-api,@aws-sdk/client-ecr,@aws-sdk/client-s3,@aws-sdk/client-secrets-manager,@aws-sdk/client-sts,@aws-sdk/credential-providers,@aws-sdk/lib-storage,archiver,glob,mime,yargs"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@smithy/types,@types/archiver,@types/glob,@types/jest,@types/mime,@types/yargs,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,fs-extra,graceful-fs,jest,jszip,prettier,projen,ts-jest,ts-node,typescript,@aws-cdk/cloud-assembly-schema,@aws-cdk/cx-api,@aws-sdk/client-ecr,@aws-sdk/client-s3,@aws-sdk/client-secrets-manager,@aws-sdk/client-sts,@aws-sdk/credential-providers,@aws-sdk/lib-storage,@smithy/config-resolver,@smithy/node-config-provider,archiver,glob,mime,yargs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @smithy/config-resolver @smithy/node-config-provider @smithy/types @types/archiver @types/glob @types/jest @types/mime @types/node @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk-client-mock aws-sdk-client-mock-jest commit-and-tag-version constructs eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint fs-extra graceful-fs jest jest-junit jszip prettier projen ts-jest ts-node typescript @aws-cdk/cloud-assembly-schema @aws-cdk/cx-api @aws-sdk/client-ecr @aws-sdk/client-s3 @aws-sdk/client-secrets-manager @aws-sdk/client-sts @aws-sdk/credential-providers @aws-sdk/lib-storage archiver glob mime yargs"
+          "exec": "yarn upgrade @smithy/types @types/archiver @types/glob @types/jest @types/mime @types/node @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-sdk-client-mock aws-sdk-client-mock-jest commit-and-tag-version constructs eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint fs-extra graceful-fs jest jest-junit jszip prettier projen ts-jest ts-node typescript @aws-cdk/cloud-assembly-schema @aws-cdk/cx-api @aws-sdk/client-ecr @aws-sdk/client-s3 @aws-sdk/client-secrets-manager @aws-sdk/client-sts @aws-sdk/credential-providers @aws-sdk/lib-storage @smithy/config-resolver @smithy/node-config-provider archiver glob mime yargs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -35,14 +35,14 @@ const project = new typescript.TypeScriptProject({
     '@aws-sdk/client-sts',
     '@aws-sdk/credential-providers',
     '@aws-sdk/lib-storage',
+    '@smithy/config-resolver',
+    '@smithy/node-config-provider',
     'glob',
     'mime',
     'yargs',
   ],
   description: 'CDK Asset Publishing Tool',
   devDeps: [
-    '@smithy/config-resolver',
-    '@smithy/node-config-provider',
     '@smithy/types',
     '@types/archiver',
     '@types/glob',
@@ -57,7 +57,7 @@ const project = new typescript.TypeScriptProject({
   packageName: 'cdk-assets',
   eslintOptions: {
     prettier: true,
-    dirs: ['src', 'test', 'bin'],
+    dirs: ['lib', 'test', 'bin'],
   },
   jestOptions: {
     jestConfig: {

--- a/lib/aws.ts
+++ b/lib/aws.ts
@@ -1,13 +1,20 @@
 import * as os from 'os';
 import { ECRClient } from '@aws-sdk/client-ecr';
-import { CompleteMultipartUploadCommandOutput, PutObjectCommandInput, S3Client } from '@aws-sdk/client-s3';
+import {
+  CompleteMultipartUploadCommandOutput,
+  PutObjectCommandInput,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { GetCallerIdentityCommand, STSClient, STSClientConfig } from '@aws-sdk/client-sts';
 import { fromNodeProviderChain, fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { Upload } from '@aws-sdk/lib-storage';
-import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from '@smithy/config-resolver';
+import {
+  NODE_REGION_CONFIG_FILE_OPTIONS,
+  NODE_REGION_CONFIG_OPTIONS,
+} from '@smithy/config-resolver';
 import { loadConfig } from '@smithy/node-config-provider';
-import { AwsCredentialIdentityProvider } from '@smithy/types';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
 
 /**
  * AWS SDK operations required by Asset Publishing
@@ -21,7 +28,10 @@ export interface IAws {
   s3Client(options: ClientOptions): Promise<S3Client>;
   ecrClient(options: ClientOptions): Promise<ECRClient>;
   secretsManagerClient(options: ClientOptions): Promise<SecretsManagerClient>;
-  upload(params: PutObjectCommandInput, options?: ClientOptions): Promise<CompleteMultipartUploadCommandOutput>;
+  upload(
+    params: PutObjectCommandInput,
+    options?: ClientOptions
+  ): Promise<CompleteMultipartUploadCommandOutput>;
 }
 
 export interface ClientOptions {
@@ -68,7 +78,7 @@ export class DefaultAwsClient implements IAws {
     process.env.AWS_PROFILE = profile;
     const clientConfig: STSClientConfig = {
       customUserAgent: USER_AGENT,
-    }
+    };
     this.config = {
       clientConfig,
       credentials: fromNodeProviderChain({
@@ -82,19 +92,22 @@ export class DefaultAwsClient implements IAws {
     return new S3Client(await this.awsOptions(options));
   }
 
-  public async upload(params: PutObjectCommandInput, options: ClientOptions = {}): Promise<CompleteMultipartUploadCommandOutput> {
+  public async upload(
+    params: PutObjectCommandInput,
+    options: ClientOptions = {}
+  ): Promise<CompleteMultipartUploadCommandOutput> {
     try {
       const upload = new Upload({
         client: await this.s3Client(options),
         params,
       });
 
-      return upload.done();
+      return await upload.done();
     } catch (e) {
       // TODO: add something more useful here
       console.log(e);
       throw e;
-    } 
+    }
   }
 
   public async ecrClient(options: ClientOptions): Promise<ECRClient> {

--- a/lib/private/docker-credentials.ts
+++ b/lib/private/docker-credentials.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { ECRClient, GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
+import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { Logger } from './shell';
 import { IAws } from '../aws';
-import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
-import { ECRClient, GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
 
 export interface DockerCredentials {
   readonly Username: string;
@@ -107,7 +107,7 @@ export async function obtainEcrCredentials(ecr: ECRClient, logger?: Logger) {
   if (logger) {
     logger('Fetching ECR authorization token');
   }
-  
+
   const authData = (await ecr.send(new GetAuthorizationTokenCommand({}))).authorizationData || [];
   if (authData.length === 0) {
     throw new Error('No authorization data received from ECR');

--- a/lib/private/docker.ts
+++ b/lib/private/docker.ts
@@ -1,10 +1,10 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { ECRClient } from '@aws-sdk/client-ecr';
 import { cdkCredentialsConfig, obtainEcrCredentials } from './docker-credentials';
 import { Logger, shell, ShellOptions, ProcessFailedError } from './shell';
 import { createCriticalSection } from './util';
-import { ECRClient } from '@aws-sdk/client-ecr';
 
 interface BuildOptions {
   readonly directory: string;

--- a/lib/private/handlers/container-images.ts
+++ b/lib/private/handlers/container-images.ts
@@ -1,6 +1,10 @@
 import * as path from 'path';
 import { DockerImageDestination } from '@aws-cdk/cloud-assembly-schema';
-import { DescribeImagesCommand, DescribeRepositoriesCommand, type ECRClient } from '@aws-sdk/client-ecr';
+import {
+  DescribeImagesCommand,
+  DescribeRepositoriesCommand,
+  type ECRClient,
+} from '@aws-sdk/client-ecr';
 import { DockerImageManifestEntry } from '../../asset-manifest';
 import { EventType } from '../../progress';
 import { IAssetHandler, IHandlerHost, IHandlerOptions } from '../asset-handler';
@@ -274,7 +278,7 @@ async function imageExists(ecr: ECRClient, repositoryName: string, imageTag: str
 async function repositoryUri(ecr: ECRClient, repositoryName: string): Promise<string | undefined> {
   try {
     const command = new DescribeRepositoriesCommand({
-      repositoryNames: [ repositoryName ],
+      repositoryNames: [repositoryName],
     });
 
     const response = await ecr.send(command);

--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -1,6 +1,12 @@
 import { createReadStream, promises as fs } from 'fs';
 import * as path from 'path';
 import { FileAssetPackaging, FileSource } from '@aws-cdk/cloud-assembly-schema';
+import {
+  GetBucketEncryptionCommand,
+  GetBucketLocationCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import * as mime from 'mime';
 import { FileManifestEntry } from '../../asset-manifest';
 import { EventType } from '../../progress';
@@ -9,7 +15,6 @@ import { IAssetHandler, IHandlerHost } from '../asset-handler';
 import { pathExists } from '../fs-extra';
 import { replaceAwsPlaceholders } from '../placeholders';
 import { shell } from '../shell';
-import { GetBucketEncryptionCommand, GetBucketLocationCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
 
 /**
  * The size of an empty zip file is 22 bytes
@@ -203,7 +208,7 @@ async function objectExists(s3: S3Client, bucket: string, key: string) {
    * never retry building those assets without users having to manually clear
    * their bucket, which is a bad experience.
    */
-  const command = new ListObjectsV2Command({ 
+  const command = new ListObjectsV2Command({
     Bucket: bucket,
     Prefix: key,
     MaxKeys: 1,
@@ -270,7 +275,7 @@ class BucketInformation {
 
   private async _bucketOwnership(s3: S3Client, bucket: string): Promise<BucketOwnership> {
     try {
-      const command = new GetBucketLocationCommand({ 
+      const command = new GetBucketLocationCommand({
         Bucket: bucket,
       });
       await s3.send(command);
@@ -293,8 +298,9 @@ class BucketInformation {
       const l = encryption?.ServerSideEncryptionConfiguration?.Rules?.length ?? 0;
       if (l > 0) {
         const apply =
-          encryption?.ServerSideEncryptionConfiguration?.Rules?.at(0)
-            ?.ApplyServerSideEncryptionByDefault;
+          encryption?.ServerSideEncryptionConfiguration?.Rules?.at(
+            0
+          )?.ApplyServerSideEncryptionByDefault;
         let ssealgo = apply?.SSEAlgorithm;
         if (ssealgo === 'AES256') return { type: 'aes256' };
         if (ssealgo === 'aws:kms') return { type: 'kms', kmsKeyId: apply?.KMSMasterKeyID };

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "projen": "npx projen"
   },
   "devDependencies": {
-    "@smithy/config-resolver": "^3.0.5",
-    "@smithy/node-config-provider": "^3.1.4",
     "@smithy/types": "^3.3.0",
     "@types/archiver": "^5.3.4",
     "@types/glob": "^7.2.0",
@@ -72,6 +70,8 @@
     "@aws-sdk/client-sts": "^3.637.0",
     "@aws-sdk/credential-providers": "^3.637.0",
     "@aws-sdk/lib-storage": "^3.637.0",
+    "@smithy/config-resolver": "^3.0.5",
+    "@smithy/node-config-provider": "^3.1.4",
     "archiver": "^5.3.2",
     "glob": "^7.2.3",
     "mime": "^2.6.0",


### PR DESCRIPTION
ESLint was effectively disabled because it was running against `src`, but this project uses `lib` as its source directory.

The CDK is [not yet using v3](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk/package.json#L107), so we haven't seen the affects of the violations.