### PR TITLE
feat: empty release to bump the latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,4 @@ By default, the AWS CDK will build and publish Docker image assets using the
 `docker` command. However, by specifying the `CDK_DOCKER` environment variable,
 you can override the command that will be used to build and publish your
 assets.
+


### PR DESCRIPTION
Ok this is a weird one. The latest release in this repo is [2.152.0](https://github.com/cdklabs/cdk-assets/releases/tag/v2.152.0), but version 2.153.0 also [exist](https://www.npmjs.com/package/cdk-assets/v/2.153.0) on NPM.

This is because there was a time window where `cdk-assets` was still being published from aws-cdk, even though its code was already authored in this repo. So what happens now is that [releases](https://github.com/cdklabs/cdk-assets/actions/runs/10939871987/job/30371119409) in this repo don't actually get published to NPM:

```console
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/cdk-assets - You cannot publish over the previously published versions: 2.152.0.
npm error 403 In most cases, you or one of your dependencies are requesting
npm error 403 a package version that is forbidden by your security policy, or
npm error 403 on a server you do not have access to.
```

The first version where `cdk-assets` was no longer published from aws-cdk is [2.154.0](https://github.com/aws/aws-cdk/tree/v2.154.0/packages), so in order to get this repo publishing normally, we need to perform two "empty release" to catch up the version number. Luckily its just 2 so lets do it manually. 