### PR TITLE
feat: detect foreign bucket ownership

### DIFF
--- a/bin/logging.ts
+++ b/bin/logging.ts
@@ -24,3 +24,7 @@ export function log(level: LogLevel, message: string) {
     console.error(`${level.padEnd(7, ' ')}: ${message}`);
   }
 }
+
+export function verbose(message: string) {
+  log('verbose', message);
+}

--- a/bin/logging.ts
+++ b/bin/logging.ts
@@ -24,7 +24,3 @@ export function log(level: LogLevel, message: string) {
     console.error(`${level.padEnd(7, ' ')}: ${message}`);
   }
 }
-
-export function verbose(message: string) {
-  log('verbose', message);
-}

--- a/lib/private/asset-handler.ts
+++ b/lib/private/asset-handler.ts
@@ -3,6 +3,19 @@ import { IAws } from '../aws';
 import { EventType } from '../progress';
 
 /**
+ * Options for publishing an asset.
+ */
+export interface PublishOptions {
+  /**
+   * Whether or not to allow cross account publishing. That is,
+   * publish to a bucket belonging to a different account than the target account.
+   *
+   * @default true
+   */
+  readonly allowCrossAccount?: boolean;
+}
+
+/**
  * Handler for asset building and publishing.
  */
 export interface IAssetHandler {
@@ -14,7 +27,7 @@ export interface IAssetHandler {
   /**
    * Publish the asset.
    */
-  publish(): Promise<void>;
+  publish(options?: PublishOptions): Promise<void>;
 
   /**
    * Return whether the asset already exists

--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -67,7 +67,6 @@ export class FileAssetHandler implements IAssetHandler {
       (await this.host.aws.discoverTargetAccount(clientOptions)).accountId;
 
     const allowCrossAccount = options.allowCrossAccount ?? true;
-
     switch (
       await bucketInfo.bucketOwnership(
         s3,

--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -51,7 +51,7 @@ export class FileAssetHandler implements IAssetHandler {
     return false;
   }
 
-  public async publish(options: PublishOptions): Promise<void> {
+  public async publish(options: PublishOptions = {}): Promise<void> {
     const destination = await replaceAwsPlaceholders(this.asset.destination, this.host.aws);
     const s3Url = `s3://${destination.bucketName}/${destination.objectKey}`;
 

--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -60,9 +60,14 @@ export class FileAssetHandler implements IAssetHandler {
     this.host.emitMessage(EventType.CHECK, `Check ${s3Url}`);
 
     const bucketInfo = BucketInformation.for(this.host);
+
+    // A thunk for describing the current account. Used when we need to format an error
+    // message, not in the success case.
+    const account = async () =>
+      (await this.host.aws.discoverTargetAccount(clientOptions)).accountId;
+
     const allowCrossAccount = options.allowCrossAccount ?? true;
 
-    const account = async () => (await this.host.aws.discoverTargetAccount(destination)).accountId;
     switch (
       await bucketInfo.bucketOwnership(
         s3,

--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -90,6 +90,7 @@ export class FileAssetHandler implements IAssetHandler {
             `Bucket named '${destination.bucketName}' exists, but not in account ${await account()}. Wrong account?`
           );
         }
+        break;
     }
 
     if (await objectExists(s3, destination.bucketName, destination.objectKey)) {

--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -278,8 +278,8 @@ class BucketInformation {
       const anyAccountOwnership = await this._bucketOwnership(s3, bucket);
 
       if (anyAccountOwnership === BucketOwnership.MINE) {
-        const myAccountOwnership = await this._bucketOwnership(s3, bucket, account);
-        if (myAccountOwnership === BucketOwnership.NO_ACCESS) {
+        const targetAccountOwnership = await this._bucketOwnership(s3, bucket, account);
+        if (targetAccountOwnership === BucketOwnership.NO_ACCESS) {
           return BucketOwnership.SOMEONE_ELSES;
         }
       }

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -347,6 +347,18 @@ test('correctly identify asset path if path is absolute', async () => {
   expect(true).toBeTruthy(); // No exception, satisfy linter
 });
 
+test('fails when bucket contains account id but doesnt belong to us', async () => {
+  const pub = new AssetPublishing(AssetManifest.fromPath('/abs/cdk.out'), { aws });
+
+  aws.mockS3.getBucketLocation = jest.fn().mockImplementation(() => {
+    throw new Error('asd');
+  });
+
+  await pub.publish();
+
+  expect(true).toBeTruthy(); // No exception, satisfy linter
+});
+
 describe('external assets', () => {
   let pub: AssetPublishing;
   beforeEach(() => {

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -407,7 +407,7 @@ test('fails when we dont have access to the bucket', async () => {
     };
   });
 
-  await expect(pub.publish()).rejects.toThrow('we have no access to it');
+  await expect(pub.publish()).rejects.toThrow('but we dont have access to it');
 });
 
 test('fails when bucket contains account id but doesnt belong to us', async () => {

--- a/test/mock-aws.ts
+++ b/test/mock-aws.ts
@@ -1,6 +1,8 @@
 jest.mock('aws-sdk');
 import * as AWS from 'aws-sdk';
 
+export const TARGET_ACCOUNT = 'target_account';
+
 export function mockAws() {
   const mockEcr = new AWS.ECR();
   const mockS3 = new AWS.S3();
@@ -31,7 +33,7 @@ export function mockAws() {
     ),
     discoverDefaultRegion: jest.fn(() => Promise.resolve('current_region')),
     discoverTargetAccount: jest.fn(() =>
-      Promise.resolve({ accountId: 'target_account', partition: 'swa' })
+      Promise.resolve({ accountId: TARGET_ACCOUNT, partition: 'swa' })
     ),
     ecrClient: jest.fn(() => Promise.resolve(mockEcr)),
     s3Client: jest.fn(() => Promise.resolve(mockS3)),


### PR DESCRIPTION
Currently, we don't differentiate between when:

1) We don't have access to the bootstrap bucket
2) We have access, but the bootstrap bucket belongs to a foreign account

It makes it so we treat (2) as a valid bucket ownership. This may or may not be desirable. 
This PR adds the aforementioned differentiation, allowing us to treat foreign bucket ownership is a special way.   

The trick is to call `s3.getBucketLocation` twice: 1) without `ExpectedBucketOwner` and 2) with `ExpectedBucketOwner` set to the target account. If (1) results in a success, but (2) results in `NO_ACCESS`, we determine we have access, but the bucket doesn't belong to the target account.

In addition, add an option to instruct asset publishing to fail if indeed a foreign bucket is detected. 