### PR TITLE
feat: detect foreign bucket ownership

### DIFF
--- a/lib/private/asset-handler.ts
+++ b/lib/private/asset-handler.ts
@@ -3,6 +3,19 @@ import { IAws } from '../aws';
 import { EventType } from '../progress';
 
 /**
+ * Options for publishing an asset.
+ */
+export interface PublishOptions {
+  /**
+   * Whether or not to allow cross account publishing. That is,
+   * publish to a bucket belonging to a different account than the target account.
+   *
+   * @default true
+   */
+  readonly allowCrossAccount?: boolean;
+}
+
+/**
  * Handler for asset building and publishing.
  */
 export interface IAssetHandler {
@@ -14,7 +27,7 @@ export interface IAssetHandler {
   /**
    * Publish the asset.
    */
-  publish(): Promise<void>;
+  publish(options?: PublishOptions): Promise<void>;
 
   /**
    * Return whether the asset already exists


### PR DESCRIPTION
Copied from https://github.com/cdklabs/cdk-assets/pull/111, and subsequent changes, related to detecting foreign bucket ownership. Unit tests were adapted to AWS SDK v3.

