### PR TITLE
fix: force SHA256 checksums

### DIFF
--- a/lib/private/handlers/files.ts
+++ b/lib/private/handlers/files.ts
@@ -5,6 +5,7 @@ import * as mime from 'mime';
 import { destinationToClientOptions } from '.';
 import { FileManifestEntry } from '../../asset-manifest';
 import { IS3Client } from '../../aws';
+import { PutObjectCommandInput } from '../../aws-types';
 import { EventType } from '../../progress';
 import { zipDirectory } from '../archive';
 import { IAssetHandler, IHandlerHost, type PublishOptions } from '../asset-handler';
@@ -88,22 +89,22 @@ export class FileAssetHandler implements IAssetHandler {
       case BucketOwnership.SOMEONE_ELSES_AND_HAVE_ACCESS:
         if (!allowCrossAccount) {
           throw new Error(
-            `❗❗ UNEXPECTED BUCKET OWNER DETECTED ❗❗ 
-        
-              We've detected that the S3 bucket ${destination.bucketName} was 
-              originally created in account ${await account()} as part of the CloudFormation stack CDKToolkit, 
-              but now resides in a different AWS account. To prevent cross-account asset bucket access of your 
+            `❗❗ UNEXPECTED BUCKET OWNER DETECTED ❗❗
+
+              We've detected that the S3 bucket ${destination.bucketName} was
+              originally created in account ${await account()} as part of the CloudFormation stack CDKToolkit,
+              but now resides in a different AWS account. To prevent cross-account asset bucket access of your
               deployments, CDK will stop now.
 
-              If this situation is intentional and you own the AWS account that the bucket has moved to, remove the 
-              resource named StagingBucket from the template of CloudFormation stack CDKToolkit and try again. 
-              
-              If this situation is not intentional, we strongly recommend auditing your account to make sure all 
-              resources are configured the way you expect them [1]. For questions or concerns, please contact 
-              AWS Support [2]. 
-              
+              If this situation is intentional and you own the AWS account that the bucket has moved to, remove the
+              resource named StagingBucket from the template of CloudFormation stack CDKToolkit and try again.
+
+              If this situation is not intentional, we strongly recommend auditing your account to make sure all
+              resources are configured the way you expect them [1]. For questions or concerns, please contact
+              AWS Support [2].
+
               [1] https://repost.aws/knowledge-center/potential-account-compromise
-              
+
               [2] https://aws.amazon.com/support`
           );
         }
@@ -162,7 +163,8 @@ export class FileAssetHandler implements IAssetHandler {
         Key: destination.objectKey,
         Body: createReadStream(publishFile.packagedPath),
         ContentType: publishFile.contentType,
-      },
+        ChecksumAlgorithm: 'SHA256',
+      } satisfies PutObjectCommandInput,
       paramsEncryption
     );
 

--- a/scripts/manual-test-manifest.json
+++ b/scripts/manual-test-manifest.json
@@ -1,0 +1,12 @@
+{
+  "version": "38.0.1",
+  "files": {
+    "asset1": {
+      "type": "file",
+      "source": { "path": "/Users/huijbers/Downloads/HEY-arm64.dmg" },
+      "destinations": {
+        "dest1": { "bucketName": "huijbers-test-objectlock", "objectKey": "hey.dmg" }
+      }
+    }
+  }
+}

--- a/scripts/manual-test.sh
+++ b/scripts/manual-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+scriptdir=$(cd $(dirname $0) && pwd)
+
+path=$(realpath $1)
+
+cat <<EOF > $scriptdir/manual-test-manifest.json
+{
+  "version": "38.0.1",
+  "files": {
+    "asset1": {
+      "type": "file",
+      "source": { "path": "$path" },
+      "destinations": {
+        "dest1": { "bucketName": "$2", "objectKey": "$3" }
+      }
+    }
+  }
+}
+EOF
+
+npx ts-node $scriptdir/../bin/cdk-assets.ts -v -p $scriptdir/manual-test-manifest.json publish


### PR DESCRIPTION
By default, the S3 client will use MD5 checksums. But in FIPS environments, those MD5 checksums will not work because Node will not have access to an M5 digest.

Force the usage of SHA256 for these checksums instead. In SDKv3, this is as simple as configuring the algorithm to use, and the SDK itself will do the rest.

Relates to https://github.com/aws/aws-cdk/issues/31926