### PR TITLE
fix: upload to Object Lock-enabled bucket fails

### DIFF
--- a/lib/aws.ts
+++ b/lib/aws.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import * as os from 'os';
 
 /**
@@ -71,16 +72,27 @@ export class DefaultAwsClient implements IAws {
   }
 
   public async s3Client(options: ClientOptions) {
-    return new this.AWS.S3({
+    const fipsOptions = {
       // In FIPS enabled environments, the MD5 algorithm is not available for use in crypto module.
       // However by default the S3 client is using an MD5 checksum for content integrity checking.
       // While this usage is technically allowed in FIPS (MD5 is only prohibited for cryptographic use),
       // in practice it is just easier to use an allowed checksum mechanism.
       // We are disabling the S3 content checksums, and are re-enabling the regular SigV4 body signing.
-      // SigV4 uses SHA256 for their content checksum. This configuration matches the default behavior
-      // of the AWS SDKv3 and is a safe choice for all users.
+      // SigV4 uses SHA256 for their content checksum.
+      //
+      // As far as we know, this configuration will work for most APIs except:
+      // - DeleteObjects (note the plural)
+      // - PutObject to a bucket with Object Lock enabled.
+      //
+      // These APIs refuse to work without a content checksum at the S3 level (a SigV4 checksum is not
+      // good enough). There is no way to get those to work with SHA256 in the SDKv2, but this limitation
+      // will be alleviated once we migrate to SDKv3.
       s3DisableBodySigning: false,
       computeChecksums: false,
+    };
+
+    return new this.AWS.S3({
+      ...(crypto.getFips() ? fipsOptions : {}),
       ...(await this.awsOptions(options)),
     });
   }

--- a/scripts/manual-test-manifest.json
+++ b/scripts/manual-test-manifest.json
@@ -1,0 +1,12 @@
+{
+  "version": "38.0.1",
+  "files": {
+    "asset1": {
+      "type": "file",
+      "source": { "path": "/Users/huijbers/Downloads/HEY-arm64.dmg" },
+      "destinations": {
+        "dest1": { "bucketName": "huijbers-test-objectlock", "objectKey": "hey-arm64.dmg" }
+      }
+    }
+  }
+}

--- a/scripts/manual-test.sh
+++ b/scripts/manual-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu
+scriptdir=$(cd $(dirname $0) && pwd)
+
+path=$(realpath $1)
+
+cat <<EOF > $scriptdir/manual-test-manifest.json
+{
+  "version": "38.0.1",
+  "files": {
+    "asset1": {
+      "type": "file",
+      "source": { "path": "$path" },
+      "destinations": {
+        "dest1": { "bucketName": "$2", "objectKey": "$3" }
+      }
+    }
+  }
+}
+EOF
+
+npx ts-node $scriptdir/../bin/cdk-assets.ts -v -p $scriptdir/manual-test-manifest.json publish


### PR DESCRIPTION
We thought disabling a content checksum for S3 clients would work in all scenarios, so that we can use the same S3 client config for FIPS and non-FIPS environments. Turns out that yet another scenario requires content checksums: PutObject to an Object Lock-enabled S3 bucket.

Again, there's no way to make this work with SDKv2. We do the best we can do: turn off MD5 signing only for FIPS environments. Result: it will not be possible to use Object Lock in FIPS environments.

But at least we unbreak the scenario for non-FIPS customers.

Relates to https://github.com/aws/aws-cdk/issues/31926
