### PR TITLE
chore: bump `mock-fs` to fix tests on Node 20

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -96,6 +96,7 @@
     },
     {
       "name": "mock-fs",
+      "version": "^5",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -245,7 +245,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/archiver,@types/glob,@types/jest,@types/mime,@types/mock-fs,@types/node,@types/yargs,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,fs-extra,graceful-fs,jest,jszip,mock-fs,prettier,projen,ts-jest,ts-node,typescript,@aws-cdk/cloud-assembly-schema,@aws-cdk/cx-api,archiver,aws-sdk,glob,mime,yargs"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/archiver,@types/glob,@types/jest,@types/mime,@types/mock-fs,@types/node,@types/yargs,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,fs-extra,graceful-fs,jest,jszip,prettier,projen,ts-jest,ts-node,typescript,@aws-cdk/cloud-assembly-schema,@aws-cdk/cx-api,archiver,aws-sdk,glob,mime,yargs"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -36,7 +36,7 @@ const project = new typescript.TypeScriptProject({
     'fs-extra',
     'graceful-fs',
     'jszip',
-    'mock-fs',
+    'mock-fs@^5',
   ],
   packageName: 'cdk-assets',
   eslintOptions: {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jest": "^29.7.0",
     "jest-junit": "^15",
     "jszip": "^3.10.1",
-    "mock-fs": "^4.14.0",
+    "mock-fs": "^5",
     "prettier": "^3.3.3",
     "projen": "^0.90.0",
     "ts-jest": "^29.2.5",

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -411,7 +411,7 @@ describe('external assets', () => {
 test('fails when we dont have access to the bucket', async () => {
   const pub = new AssetPublishing(AssetManifest.fromPath('/simple/cdk.out'), { aws });
 
-  aws.mockS3.getBucketLocation = jest.fn().mockImplementation((req: any) => {
+  aws.mockS3.getBucketLocation = jest.fn().mockImplementation((_req: any) => {
     return {
       promise: () => {
         throw errorWithCode('AccessDenied', 'Whatever');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,10 +3933,10 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mock-fs@^4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
-  integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
+mock-fs@^5:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.4.1.tgz#b00abc658cb19dbbf282fde2f05bb751cd1e12a5"
+  integrity sha512-sz/Q8K1gXXXHR+qr0GZg2ysxCRr323kuN10O7CtQjraJsFDJ4SJ+0I5MzALz7aRp9lHk8Cc/YdsT95h9Ka1aFw==
 
 modify-values@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`mock-fs@4` doesn't work on Node 20. `mock-fs@5` does.
