### PR TITLE
chore: tests are not isolated

### DIFF
--- a/lib/aws.ts
+++ b/lib/aws.ts
@@ -154,16 +154,11 @@ export class DefaultAwsClient implements IAws {
       listObjectsV2: (input: ListObjectsV2CommandInput): Promise<ListObjectsV2CommandOutput> =>
         client.send(new ListObjectsV2Command(input)),
       upload: (input: PutObjectCommandInput): Promise<CompleteMultipartUploadCommandOutput> => {
-        try {
-          const upload = new Upload({
-            client,
-            params: input,
-          });
-          return upload.done();
-        } catch (e: any) {
-          console.log(`Asset upload failed: '${e.message}'`);
-          throw e;
-        }
+        const upload = new Upload({
+          client,
+          params: input,
+        });
+        return upload.done();
       },
     };
   }

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -328,9 +328,9 @@ test('correctly identify asset path if path is absolute', async () => {
   const pub = new AssetPublishing(AssetManifest.fromPath(mockfs.path('/abs/cdk.out')), { aws });
   s3.on(ListObjectsV2Command).resolves({ Contents: undefined });
 
-  expect(async () => {
-    await pub.publish();
-  }).not.toThrow();
+  await pub.publish();
+
+  // THEN: doesn't throw
 });
 
 describe('external assets', () => {
@@ -365,7 +365,7 @@ describe('external assets', () => {
 
     await pub.publish();
 
-    expect(s3).toHaveReceivedCommandTimes(PutObjectCommand, 2);
+    expect(s3).toHaveReceivedCommandTimes(PutObjectCommand, 1);
 
     expectAllSpawns();
   });


### PR DESCRIPTION
The `upload external asset correctly` test was asserting that `PutObject` would be called twice, but it was only called twice because a test run prior to it leaked a `PubObject` invocation that was counted towards the count of this test.

If the test was run by itself, the `PutObject` count was `1`, not `2`, and the test would fail.

Also remove a log statement that breaks the linter in the new repo.
