### PR TITLE
chore: fix order-dependent tests

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -63,6 +63,7 @@ const project = new typescript.TypeScriptProject({
     jestConfig: {
       verbose: true,
       maxWorkers: '50%',
+      randomize: true,
     },
     configFilePath: 'jest.config.json',
   },

--- a/jest.config.json
+++ b/jest.config.json
@@ -2,6 +2,7 @@
   "coverageProvider": "v8",
   "verbose": true,
   "maxWorkers": "50%",
+  "randomize": true,
   "testMatch": [
     "<rootDir>/@(lib|test)/**/*(*.)@(spec|test).ts?(x)",
     "<rootDir>/@(lib|test)/**/__tests__/**/*.ts?(x)",

--- a/lib/private/docker-credentials.ts
+++ b/lib/private/docker-credentials.ts
@@ -47,6 +47,13 @@ export function cdkCredentialsConfig(): DockerCredentialsConfig | undefined {
   return _cdkCredentials;
 }
 
+/**
+ * Just for testing
+ */
+export function _clearCdkCredentialsConfigCache() {
+  _cdkCredentials = undefined;
+}
+
 /** Fetches login credentials from the configured source (e.g., SecretsManager, ECR) */
 export async function fetchDockerLoginCredentials(
   aws: IAws,

--- a/test/mock-aws.ts
+++ b/test/mock-aws.ts
@@ -6,25 +6,26 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { Account, ClientOptions, DefaultAwsClient } from '../lib/aws';
 
 export const mockEcr = mockClient(ECRClient);
-mockEcr.on(DescribeRepositoriesCommand).resolves({
-  repositories: [
-    {
-      repositoryName: 'repo',
-      repositoryUri: '12345.amazonaws.com/repo',
-    },
-  ],
-});
-mockEcr.on(DescribeImagesCommand).resolves({});
-
 export const mockS3 = mockClient(S3Client);
-mockS3.on(UploadPartCommand).resolves({ ETag: '1' });
-mockS3.on(PutObjectCommand).resolves({});
-
 export const mockSecretsManager = mockClient(SecretsManagerClient);
 export const mockSTS = mockClient(STSClient);
-mockSTS
-  .on(GetCallerIdentityCommand)
-  .resolves({ Account: '123456789012', Arn: 'aws:swa:123456789012:some-other-stuff' });
+
+export function resetDefaultAwsMockBehavior() {
+  mockEcr.on(DescribeRepositoriesCommand).resolves({
+    repositories: [
+      {
+        repositoryName: 'repo',
+        repositoryUri: '12345.amazonaws.com/repo',
+      },
+    ],
+  });
+  mockEcr.on(DescribeImagesCommand).resolves({});
+  mockS3.on(UploadPartCommand).resolves({ ETag: '1' });
+  mockS3.on(PutObjectCommand).resolves({});
+  mockSTS
+    .on(GetCallerIdentityCommand)
+    .resolves({ Account: '123456789012', Arn: 'aws:swa:123456789012:some-other-stuff' });
+}
 
 export class MockAws extends DefaultAwsClient {
   discoverPartition(): Promise<string> {

--- a/test/placeholders.test.ts
+++ b/test/placeholders.test.ts
@@ -3,12 +3,13 @@ import 'aws-sdk-client-mock-jest';
 import { Manifest } from '@aws-cdk/cloud-assembly-schema';
 import { DescribeImagesCommand } from '@aws-sdk/client-ecr';
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
-import { MockAws, mockEcr, mockS3 } from './mock-aws';
+import { MockAws, mockEcr, mockS3, resetDefaultAwsMockBehavior } from './mock-aws';
 import mockfs from './mock-fs';
 import { AssetManifest, AssetPublishing, IAws } from '../lib';
 
 let aws: IAws;
 beforeEach(() => {
+  resetDefaultAwsMockBehavior();
   mockfs({
     '/simple/cdk.out/assets.json': JSON.stringify({
       version: Manifest.version(),

--- a/test/private/docker-credentials.test.ts
+++ b/test/private/docker-credentials.test.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import { GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';


### PR DESCRIPTION
This had some tests that depended on order because they polluted mocks outside the test.

Fix that.
