### PR TITLE
chore: make compilation succeed with stricter tsconfig settings

### DIFF
--- a/test/docker-images.test.ts
+++ b/test/docker-images.test.ts
@@ -297,10 +297,11 @@ test('logging in twice for two repository domains (containing account id & regio
   });
 
   mockEcr.on(DescribeRepositoriesCommand).callsFake((input) => {
-    const url = {
+    const repos: Record<string, string> = {
       repo: '12345.amazonaws.com/repo',
       repo2: '12346.amazonaws.com/repo2',
-    }[input.repositoryNames[0]];
+    };
+    const url = repos[input.repositoryNames[0]];
     if (!url) {
       throw new Error(`Unexpected repo: ${JSON.stringify(input)}`);
     }


### PR DESCRIPTION
These tsconfig settings apply in the new moved CLI project becase

I don't quite understand WHY the flags are different that this failed compilation, but it did and this fixes it.