### PR TITLE
fix: outdated dependency on `@aws-cdk/cloud-assembly-schema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@aws-cdk/cloud-assembly-schema": "^38.0.1",
+    "@aws-cdk/cloud-assembly-schema": "^39.1.34",
     "@aws-cdk/cx-api": "^2.173.4",
     "@aws-sdk/client-ecr": "^3.720.0",
     "@aws-sdk/client-s3": "^3.717.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/cloud-assembly-schema@^38.0.1":
-  version "38.0.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz#cdf4684ae8778459e039cd44082ea644a3504ca9"
-  integrity sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==
+"@aws-cdk/cloud-assembly-schema@^39.1.34":
+  version "39.1.34"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.1.34.tgz#06bfc07cd892bf431f97c8ff784c8b001480c134"
+  integrity sha512-/uDvlrOD67PAaMxEX/gbWA8tce9SdVkGBtxEXV/R+DN7z6T4BztX3aZhkjMP/mzWu0UbkgOkwbOzqD4terCGwg==
   dependencies:
     jsonschema "^1.4.1"
     semver "^7.6.3"


### PR DESCRIPTION
In https://github.com/cdklabs/cloud-assembly-schema/pull/61, we bumped the schema version 39, but we didn't upgrade the dependency. 