### PR TITLE
fix: outdated dependency on `@aws-cdk/cloud-assembly-schema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@aws-cdk/cloud-assembly-schema": "^39.0.1",
+    "@aws-cdk/cloud-assembly-schema": "^39.1.34",
     "@aws-cdk/cx-api": "^2.174.0",
     "archiver": "^5.3.2",
     "aws-sdk": "^2.1692.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@aws-cdk/cloud-assembly-schema": "^38.0.1",
+    "@aws-cdk/cloud-assembly-schema": "^39.0.1",
     "@aws-cdk/cx-api": "^2.174.0",
     "archiver": "^5.3.2",
     "aws-sdk": "^2.1692.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/cloud-assembly-schema@^38.0.1":
-  version "38.0.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz#cdf4684ae8778459e039cd44082ea644a3504ca9"
-  integrity sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==
+"@aws-cdk/cloud-assembly-schema@^39.0.1":
+  version "39.1.38"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.1.38.tgz#7232f922e91e34f1225b5b41d318b77eed377fd0"
+  integrity sha512-T5nc7+y3pmfXD/LNft1mA8E8Q6IdsE0mta5nC1FZu5sQd+LUo9xGd0BwdzJpR54cgTW/bNcIs5ARoc6kWoRJaA==
   dependencies:
     jsonschema "^1.4.1"
     semver "^7.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aws-cdk/cloud-assembly-schema@^39.0.1":
+"@aws-cdk/cloud-assembly-schema@^39.1.34":
   version "39.1.38"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.1.38.tgz#7232f922e91e34f1225b5b41d318b77eed377fd0"
   integrity sha512-T5nc7+y3pmfXD/LNft1mA8E8Q6IdsE0mta5nC1FZu5sQd+LUo9xGd0BwdzJpR54cgTW/bNcIs5ARoc6kWoRJaA==


### PR DESCRIPTION
Backport of https://github.com/cdklabs/cdk-assets/pull/277. 

CDK pipeliens use `npm install -g cdk-assets@latest` to grab a version of `cdk-assets`, but since the 3.x version line is still an RC, the `latest` tag still points to the `2.x` version line.

Fixes https://github.com/aws/aws-cdk/issues/32744 