### PR TITLE
fix: make `cdk-assets` build in monorepo

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,6 +6,7 @@
     },
     {
       "name": "@smithy/types",
+      "version": "^4",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -279,7 +279,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@smithy/types,@types/archiver,@types/glob,@types/jest,@types/mime,@types/node,@types/yargs,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,fs-extra,graceful-fs,jest,jszip,madge,prettier,projen,ts-jest,ts-node,typescript,@aws-cdk/cloud-assembly-schema,@aws-cdk/cx-api,@aws-sdk/client-ecr,@aws-sdk/client-s3,@aws-sdk/client-secrets-manager,@aws-sdk/client-sts,@aws-sdk/credential-providers,@aws-sdk/lib-storage,@smithy/config-resolver,@smithy/node-config-provider,archiver,glob,mime,yargs"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/archiver,@types/glob,@types/jest,@types/mime,@types/node,@types/yargs,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,fs-extra,graceful-fs,jest,jszip,madge,prettier,projen,ts-jest,ts-node,typescript,@aws-cdk/cloud-assembly-schema,@aws-cdk/cx-api,@aws-sdk/client-ecr,@aws-sdk/client-s3,@aws-sdk/client-secrets-manager,@aws-sdk/client-sts,@aws-sdk/credential-providers,@aws-sdk/lib-storage,@smithy/config-resolver,@smithy/node-config-provider,archiver,glob,mime,yargs"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -43,7 +43,7 @@ const project = new typescript.TypeScriptProject({
   ],
   description: 'CDK Asset Publishing Tool',
   devDeps: [
-    '@smithy/types',
+    '@smithy/types@^4',
     '@types/archiver',
     '@types/glob',
     '@types/mime',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@cdklabs/eslint-plugin": "^1.3.2",
-    "@smithy/types": "^3.7.2",
+    "@smithy/types": "^4",
     "@types/archiver": "^5.3.4",
     "@types/glob": "^7.2.0",
     "@types/jest": "^29.5.14",

--- a/test/private/docker.test.ts
+++ b/test/private/docker.test.ts
@@ -13,14 +13,14 @@ describe('Docker', () => {
     const makeShellExecuteMock = (fn: (params: string[]) => void): ShellExecuteMock =>
       jest
         .spyOn<{ execute: Docker['execute'] }, 'execute'>(Docker.prototype as any, 'execute')
-        .mockImplementation(async (params: string[], _options?: ShellOptions) => fn(params));
+        .mockImplementation(async (params: string[], _options?: Omit<ShellOptions, 'shellEventPublisher'>) => fn(params));
 
     afterEach(() => {
       jest.restoreAllMocks();
     });
 
     beforeEach(() => {
-      docker = new Docker();
+      docker = new Docker(() => {}, 'ignore');
     });
 
     test('returns true when image inspect command does not throw', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,7 +1962,7 @@
   dependencies:
     tslib "^2.6.2"
 
-"@smithy/types@^4.0.0", "@smithy/types@^4.1.0":
+"@smithy/types@^4", "@smithy/types@^4.0.0", "@smithy/types@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.1.0.tgz#19de0b6087bccdd4182a334eb5d3d2629699370f"
   integrity sha512-enhjdwp4D7CXmwLtD6zbcDMbo6/T6WtuuKCY49Xxc6OMOmUWlBEBDREsxxgV2LIdeQPW756+f97GzcgAwp3iLw==


### PR DESCRIPTION
- `@smithy/types` needed to be upgraded to work with a newer version of the SDKv3
- The types in one of the test files were wrong, but those are not type checked using the current `tsconfig` configuration (but they are in the monorepo).
