### PR TITLE
fix: docker build omits attestations

### DIFF
--- a/lib/private/docker.ts
+++ b/lib/private/docker.ts
@@ -129,6 +129,9 @@ export class Docker {
     await this.execute(buildCommand, {
       cwd: options.directory,
       subprocessOutputDestination: this.subprocessOutputDestination,
+      env: {
+        BUILDX_NO_DEFAULT_ATTESTATIONS: '1', // Docker Build adds provenance attestations by default that confuse cdk-assets
+      },
     });
   }
 

--- a/test/private/docker.test.ts
+++ b/test/private/docker.test.ts
@@ -6,26 +6,25 @@ type ShellExecuteMock = jest.SpyInstance<
   Parameters<Docker['execute']>
 >;
 
+let docker: Docker;
+
+const makeShellExecuteMock = (fn: (params: string[]) => void): ShellExecuteMock =>
+  jest
+    .spyOn<{ execute: Docker['execute'] }, 'execute'>(Docker.prototype as any, 'execute')
+    .mockImplementation(
+      async (params: string[], _options?: Omit<ShellOptions, 'shellEventPublisher'>) => fn(params)
+    );
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+beforeEach(() => {
+  docker = new Docker(() => {}, 'ignore');
+});
+
 describe('Docker', () => {
   describe('exists', () => {
-    let docker: Docker;
-
-    const makeShellExecuteMock = (fn: (params: string[]) => void): ShellExecuteMock =>
-      jest
-        .spyOn<{ execute: Docker['execute'] }, 'execute'>(Docker.prototype as any, 'execute')
-        .mockImplementation(
-          async (params: string[], _options?: Omit<ShellOptions, 'shellEventPublisher'>) =>
-            fn(params)
-        );
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
-    beforeEach(() => {
-      docker = new Docker(() => {}, 'ignore');
-    });
-
     test('returns true when image inspect command does not throw', async () => {
       const spy = makeShellExecuteMock(() => undefined);
 
@@ -93,6 +92,27 @@ describe('Docker', () => {
       const imageExists = await docker.exists('foo');
 
       expect(imageExists).toBe(false);
+    });
+  });
+
+  describe('build', () => {
+    test('includes BUILDX_NO_DEFAULT_ATTESTATIONS env variable in commands', async () => {
+      const spy = makeShellExecuteMock(() => undefined);
+
+      await docker.build({
+        directory: 'foo',
+        tag: 'bar',
+      });
+
+      // Verify the options passed to build
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            BUILDX_NO_DEFAULT_ATTESTATIONS: '1',
+          }),
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
There are various issues in cdk that can be traced back to attestations in docker: 

https://github.com/aws/aws-cdk/issues/30258
https://github.com/aws/aws-cdk/issues/31549

cdk-assets cannot work with docker containerd because it will attempt to upload multiple files to the same hash in ECR, and our ECR repository is immutable (by requirement). docker recently changed their default to turn on containerd which causes this issue to skyrocket. 

the hotfix here is to add an environment variable when calling `docker` so that the attestation file is not added to the manifest. we can later look into adding support for including [provenance](https://docs.docker.com/build/metadata/attestations/slsa-provenance/) attestations if there is need for it. 